### PR TITLE
Development

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -52,7 +52,7 @@ const Home: NextPage<Props> = ({ data, wordOfDay }) => {
           synonyms[Math.ceil(synonyms.length / 2)],
           synonyms[synonyms.length - 1],
         ]
-      : [synonyms[0]]
+      : [...synonyms]
   );
   const [secretWord, setSecretWord] = useState<string>(wordOfDay);
   const [winState, setWinState] = useState<boolean>(false);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -75,23 +75,20 @@ const Home: NextPage<Props> = ({ data, wordOfDay }) => {
 
   useEffect(() => {
     const localSavedState = loadGameStateFromLocalStorage();
-    if (localSavedState) {
-      setSecretWord(localSavedState.secretWord);
-      setWinState(localSavedState.winState);
-      setGuessLst(localSavedState.myGuesses);
-      setSynos(localSavedState.synonyms);
-      setGameState(localSavedState.gameState);
-      setMyLives(localSavedState.myLives);
-      setShowInstruct(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    const localSavedState = loadGameStateFromLocalStorage();
     const checkDate = new Date();
     const offsetDate = getOffsetDay(checkDate);
-    if (offsetDate !== localSavedState?.dayOfPlay) {
-      removeGameStateFromLocalStorage();
+    if (localSavedState) {
+      if (offsetDate !== localSavedState.dayOfPlay) {
+        removeGameStateFromLocalStorage();
+      } else {
+        setSecretWord(localSavedState.secretWord);
+        setWinState(localSavedState.winState);
+        setGuessLst(localSavedState.myGuesses);
+        setSynos(localSavedState.synonyms);
+        setGameState(localSavedState.gameState);
+        setMyLives(localSavedState.myLives);
+        setShowInstruct(false);
+      }
     }
   }, []);
 

--- a/utils/hooks/useGetHint.ts
+++ b/utils/hooks/useGetHint.ts
@@ -11,7 +11,6 @@ const useGetHint = (hintSet: Set<number>, lenLst: number): number => {
     }
   }
 
-  console.log(hintSet);
   return randomHint;
 };
 


### PR DESCRIPTION
Fix:
- bug where newly occurs but the the state is already set so defaults to old state first
- shows entire array if length of synonyms array returned from api call is less than 2

chore:
- removes console log