### PR TITLE
Feat wordtriggers

### DIFF
--- a/Components/EndGame.tsx
+++ b/Components/EndGame.tsx
@@ -34,7 +34,7 @@ const EndGame: FC<endgameProps> = ({
         <div className={styles.MyGuessCon}>
           {myGuesses.map((guess, index) => (
             <p key={index} data-testid="guessEntered">
-              {guess}
+              {guess.word}
             </p>
           ))}
         </div>

--- a/Components/Modals/instructionModal.tsx
+++ b/Components/Modals/instructionModal.tsx
@@ -30,12 +30,14 @@ const instructionModal: FC = () => {
           </div>
           <div className={styles.Example__syns}>
             <div className={styles.Example__synsTags}>
-              <p className={styles.wrongGuess}>Read</p>
-              <p className={styles.wrongGuess}>Play</p>
+              <p className={styles.wrongGuess}>Screen</p>
               <p className={styles.wrongGuess}>Picture</p>
+              <p className={`${styles.wrongGuess} ${styles.trgWordGuess}`}>
+                Play
+              </p>
             </div>
             <p className={styles.Example__synsWord}>
-              Wrong guesses are in red and will appear in the guess bucket
+              {`"Play" is either a synonym or a word that is often seen in the same sentence as the secret word. "Picture" does not fit that criteria.`}
             </p>
           </div>
           <div className={styles.secretWord}>

--- a/__tests__/integration/index.test.tsx
+++ b/__tests__/integration/index.test.tsx
@@ -5,11 +5,14 @@ import Home from "../../pages/index";
 
 const stringWords = ["hello", "There", "you", "test", "test1"];
 const word: string = "there";
+const trgWordsLst = ["bob", " Apple", "trigger"];
 
 describe("Test the application for Functionality", () => {
   describe("Instruction page", () => {
     it("should mount the instruction page when page is loaded", () => {
-      render(<Home synonyms={stringWords} wordOfDay={word} />);
+      render(
+        <Home synonyms={stringWords} wordOfDay={word} trgWords={trgWordsLst} />
+      );
 
       const InstructionHeader = screen.getByText(/How to play/i);
 
@@ -22,7 +25,9 @@ describe("Test the application for Functionality", () => {
       window.localStorage.clear();
     });
     it("should allow user to submit a guess", () => {
-      render(<Home synonyms={stringWords} wordOfDay={word} />);
+      render(
+        <Home synonyms={stringWords} wordOfDay={word} trgWords={trgWordsLst} />
+      );
       const closeBtn = screen.getByTestId("instruct_Close_btn");
       fireEvent.click(closeBtn);
 
@@ -40,7 +45,9 @@ describe("Test the application for Functionality", () => {
     });
 
     it("should show the user a new synonym when the new hint btn is pressed", () => {
-      render(<Home synonyms={stringWords} wordOfDay={word} />);
+      render(
+        <Home synonyms={stringWords} wordOfDay={word} trgWords={trgWordsLst} />
+      );
       const closeBtn = screen.getByTestId("instruct_Close_btn");
       fireEvent.click(closeBtn);
 
@@ -54,7 +61,9 @@ describe("Test the application for Functionality", () => {
     });
 
     it("should show the not in word list prompt when a user enters a word that is not in the word list", () => {
-      render(<Home synonyms={stringWords} wordOfDay={word} />);
+      render(
+        <Home synonyms={stringWords} wordOfDay={word} trgWords={trgWordsLst} />
+      );
       const closeBtn = screen.getByTestId("instruct_Close_btn");
       fireEvent.click(closeBtn);
 
@@ -72,7 +81,9 @@ describe("Test the application for Functionality", () => {
     });
 
     it("should show the user that they have won the game", () => {
-      render(<Home synonyms={stringWords} wordOfDay={word} />);
+      render(
+        <Home synonyms={stringWords} wordOfDay={word} trgWords={trgWordsLst} />
+      );
       const closeBtn = screen.getByTestId("instruct_Close_btn");
       fireEvent.click(closeBtn);
 
@@ -90,7 +101,9 @@ describe("Test the application for Functionality", () => {
     });
 
     it("should show if the user has lost the game", () => {
-      render(<Home synonyms={stringWords} wordOfDay={word} />);
+      render(
+        <Home synonyms={stringWords} wordOfDay={word} trgWords={trgWordsLst} />
+      );
       const closeBtn = screen.getByTestId("instruct_Close_btn");
       fireEvent.click(closeBtn);
       const guessInput = screen.getByRole("textbox");
@@ -108,7 +121,9 @@ describe("Test the application for Functionality", () => {
     });
 
     it("should keep track of the number of guesses the user has entered", () => {
-      render(<Home synonyms={stringWords} wordOfDay={word} />);
+      render(
+        <Home synonyms={stringWords} wordOfDay={word} trgWords={trgWordsLst} />
+      );
       const closeBtn = screen.getByTestId("instruct_Close_btn");
       fireEvent.click(closeBtn);
       const guessInput = screen.getByRole("textbox");
@@ -132,7 +147,9 @@ describe("Test the application for Functionality", () => {
     });
 
     it("should decrease the life by 1 when an incorrect guess is entered", () => {
-      render(<Home synonyms={stringWords} wordOfDay={word} />);
+      render(
+        <Home synonyms={stringWords} wordOfDay={word} trgWords={trgWordsLst} />
+      );
       const closeBtn = screen.getByTestId("instruct_Close_btn");
       fireEvent.click(closeBtn);
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,6 +8,7 @@ import styles from "../styles/Home.module.css";
 import {
   resData,
   StoredGameStatistics,
+  userGuessLst,
   synonyms,
   setupValues,
   triggerWord,
@@ -71,7 +72,7 @@ const Home: NextPage<Props> = ({ synonyms, wordOfDay, trgWords }) => {
   const [winState, setWinState] = useState<boolean>(false);
   const [gameState, setGameState] = useState<boolean>(false);
   const [myLives, setMyLives] = useState(setUpValues.totalGuessAllowed);
-  const [guessLst, setGuessLst] = useState<string[]>([]);
+  const [guessLst, setGuessLst] = useState<userGuessLst[]>([]);
   const [showInstruct, setShowInstruct] = useState<boolean>(true);
   const [showAlert, setShowAlert] = useState<boolean>(false);
   const [synonymSetState, setSynonymSetState] = useState(
@@ -80,8 +81,6 @@ const Home: NextPage<Props> = ({ synonyms, wordOfDay, trgWords }) => {
   const [myGameStats, setMyGameStats] = useState<StoredGameStatistics | null>(
     null
   );
-  const [synomynBackgroundCol, setSynomynBackgroundCol] =
-    useState<string>("black");
 
   useEffect(() => {
     const myGameStatsZ = loadGameStats();
@@ -154,13 +153,6 @@ const Home: NextPage<Props> = ({ synonyms, wordOfDay, trgWords }) => {
     // reached the limit
     // if not check if the guess is equal to the secret word and add it to
     // the list of guesses.
-
-    if (trgWords.includes(myGuess.toLowerCase())) {
-      setSynomynBackgroundCol("hsl(111, 32%, 38%)");
-    } else {
-      setSynomynBackgroundCol("hsl(0, 84%, 68%)");
-    }
-
     if (myLives === 1) {
       setGameState(true);
       saveGameStateToLocalStorage({
@@ -189,8 +181,16 @@ const Home: NextPage<Props> = ({ synonyms, wordOfDay, trgWords }) => {
       });
       gameStateFunc(setUpValues.offsetDate, true);
     } else {
-      // setGuessLst((prevLst) => [...prevLst, myGuess]);
-      setGuessLst([...guessLst, myGuess]);
+      let synonymBackgroudColVar: string;
+      if (trgWords.includes(myGuess.toLowerCase())) {
+        synonymBackgroudColVar = "hsl(111, 32%, 38%)";
+      } else {
+        synonymBackgroudColVar = "hsl(0, 84%, 68%)";
+      }
+      setGuessLst((prevLst) => [
+        ...prevLst,
+        { word: myGuess, statusColour: synonymBackgroudColVar },
+      ]);
       setMyGuess("");
       setMyLives((prev) => prev - 1);
     }
@@ -230,14 +230,14 @@ const Home: NextPage<Props> = ({ synonyms, wordOfDay, trgWords }) => {
             <Synonyms synos={synos} />
 
             <section className={styles.GuessedWords}>
-              {guessLst.map((word) => (
+              {guessLst.map((word, index) => (
                 <p
-                  key={word}
+                  key={index}
                   className={styles.GuessedWords__word}
-                  style={{ backgroundColor: synomynBackgroundCol }}
+                  style={{ backgroundColor: word.statusColour }}
                   data-testid="GuessedWord"
                 >
-                  {word}
+                  {word.word}
                 </p>
               ))}
             </section>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -141,7 +141,8 @@ const Home: NextPage<Props> = ({ synonyms, wordOfDay, trgWords }) => {
     // check if the guess is in the word lst
     if (
       !wordSet.has(myGuess.toLowerCase()) &&
-      !trgWords.includes(myGuess.toLowerCase())
+      !trgWords.includes(myGuess.toLowerCase()) &&
+      !synonyms.includes(myGuess.toLowerCase())
     ) {
       setMyGuess("");
       setShowAlert(true);
@@ -182,7 +183,10 @@ const Home: NextPage<Props> = ({ synonyms, wordOfDay, trgWords }) => {
       gameStateFunc(setUpValues.offsetDate, true);
     } else {
       let synonymBackgroudColVar: string;
-      if (trgWords.includes(myGuess.toLowerCase())) {
+      if (
+        trgWords.includes(myGuess.toLowerCase()) ||
+        synonyms.includes(myGuess.toLowerCase())
+      ) {
         synonymBackgroudColVar = "hsl(111, 32%, 38%)";
       } else {
         synonymBackgroudColVar = "hsl(0, 84%, 68%)";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -303,8 +303,6 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
   const synonyms = UseGetAllSynonyms(resp[0]?.meta?.syns);
   const trgWords = UseGetTriggerWord(trgWordResp);
 
-  console.log(trgWords);
-
   return {
     props: { synonyms, wordOfDay, trgWords },
   };

--- a/styles/Instructions.module.css
+++ b/styles/Instructions.module.css
@@ -106,6 +106,10 @@
   color: var(--col-text-sec);
 }
 
+.trgWordGuess {
+  background-color: var(--col-acc-sec);
+}
+
 .Example__synsWord,
 .secretWord_WordInstuctions {
   margin-top: 0.55em;
@@ -159,6 +163,6 @@
   }
 
   .secretWord_Word {
-    background-color: var(--col-acc-sec);
+    background-color: hsl(0, 0%, 16%);
   }
 }

--- a/utils/helpers/fetchData.ts
+++ b/utils/helpers/fetchData.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const fetchData = async (route: string) => {
+  const data = await axios.get(route);
+
+  return data.data;
+};
+
+export default fetchData;

--- a/utils/hooks/useGetTriggerWords.ts
+++ b/utils/hooks/useGetTriggerWords.ts
@@ -1,0 +1,8 @@
+import { triggerWord } from "../types/projectTypes";
+const useGetTriggerWords = (lst: triggerWord[]) => {
+  const newArray = lst.map((trgWord) => trgWord.word);
+
+  return newArray;
+};
+
+export default useGetTriggerWords;

--- a/utils/hooks/usePromiseResolver.ts
+++ b/utils/hooks/usePromiseResolver.ts
@@ -1,0 +1,14 @@
+import fetchData from "../helpers/fetchData";
+
+const usePromiseResolver = async (word: string) => {
+  const resData = await Promise.all([
+    fetchData(
+      `https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${word}?key=${process.env.DICT_API_KEY}`
+    ),
+    fetchData(`https://api.datamuse.com/words?rel_trg=${word}`),
+  ]);
+
+  return resData;
+};
+
+export default usePromiseResolver;

--- a/utils/types/projectTypes.ts
+++ b/utils/types/projectTypes.ts
@@ -3,7 +3,7 @@ export interface endgameProps {
   secretWord: string;
 
   winState: boolean;
-  myGuesses: string[];
+  myGuesses: userGuessLst[];
   children: ReactNode;
 }
 
@@ -34,11 +34,16 @@ export interface triggerWord {
   score: number;
 }
 
+export interface userGuessLst {
+  word: string;
+  statusColour: string;
+}
+
 export interface StoredGameState {
   secretWord: string;
   winState: boolean;
   gameState: boolean;
-  myGuesses: string[];
+  myGuesses: userGuessLst[];
   synonyms: string[];
   myLives: number;
   dayOfPlay: number;

--- a/utils/types/projectTypes.ts
+++ b/utils/types/projectTypes.ts
@@ -9,6 +9,8 @@ export interface endgameProps {
 
 export type synonyms = string[];
 
+export type promiseResolver = [resData[], triggerWord[]];
+
 export interface resData {
   def: any;
   fl: string;
@@ -25,6 +27,11 @@ export interface resData {
     };
   };
   shortdef: string[];
+}
+
+export interface triggerWord {
+  word: string;
+  score: number;
 }
 
 export interface StoredGameState {


### PR DESCRIPTION
Feat:
- Adds trigger word prompt -> users are able to see if the word they entered is found in the same sentence as the secret word

Fix:
- Users are now able to see if the word they entered appears in the synonym list returned from the API
- updates the colours of the synonyms that are displayed

Refactor:
- Moves api cal to helper function

Chore:
- updates the instruction panel
- Modifies test to accept new props
- removes console log