### PR TITLE
fix: newhint infinate loop bug & synonyms lst

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -65,7 +65,7 @@ const Home: NextPage<Props> = ({ synonyms, wordOfDay, trgWords }) => {
     synonyms.length > 3
       ? [
           synonyms[0],
-          synonyms[Math.ceil(synonyms.length / 2)],
+          synonyms[Math.floor(synonyms.length / 2)],
           synonyms[synonyms.length - 1],
         ]
       : [...synonyms]
@@ -113,8 +113,8 @@ const Home: NextPage<Props> = ({ synonyms, wordOfDay, trgWords }) => {
   const onGetHint = () => {
     // pick a random hint and then check if the set has the hint
     // if the hint exists in the set then pick a new hints
-    if (synonymSetState.size === synonyms.length) return;
     const newHint = UseGetHint(synonymSetState, synonyms.length);
+    if (!newHint) return;
     setSynonymSetState(synonymSetState.add(newHint));
     setSynos((prevState) => [...prevState, synonyms[newHint]]);
     setMyLives((prev) => prev - 1);

--- a/utils/hooks/useGetHint.ts
+++ b/utils/hooks/useGetHint.ts
@@ -1,8 +1,10 @@
-const useGetHint = (hintSet: Set<number>, lenLst: number): number => {
+const useGetHint = (hintSet: Set<number>, lenLst: number) => {
   let newHint = false;
 
   let randomHint: number = 0;
   let counter: number = 0;
+
+  if (hintSet.size === lenLst) return;
 
   while (newHint === false || counter > lenLst) {
     counter++;


### PR DESCRIPTION
Fix:
- Issue with new hint button remaining to cause an infinite loop when the set is almost full
- Fix initial synonym list -> aligns it with the set