### PR TITLE
fix: bug with sync time on server and local

### DIFF
--- a/utils/helpers/newDay.ts
+++ b/utils/helpers/newDay.ts
@@ -1,7 +1,7 @@
 import WordLst from "../../shufflewordLst.json";
 
 export const getOffsetDay = (currDate: Date): number => {
-  const baseLineDay = new Date("July 19, 2022 04:00:00");
+  const baseLineDay = new Date("July 19, 2022 04:00:00 UTC");
 
   const offSet: number = Math.floor(currDate.valueOf() - baseLineDay.valueOf());
   const toDaysConverter = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
Fix:
- bug where time on the server did not match time on local machine. Therefore causing a sync error on new day for the word.